### PR TITLE
final round of improvements

### DIFF
--- a/forward/ft_compute_leadfield.m
+++ b/forward/ft_compute_leadfield.m
@@ -30,7 +30,7 @@ function [lf] = ft_compute_leadfield(dippos, sens, headmodel, varargin)
 %   'backproject'     = 'yes' or 'no', in the case of a rank reduction this parameter determines whether the result will be backprojected onto the original subspace (default = 'yes')
 %   'normalize'       = 'no', 'yes' or 'column'
 %   'normalizeparam'  = parameter for depth normalization (default = 0.5)
-%   'weight'          = number or 1xN vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
+%   'weight'          = number or Nx1 vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
 %
 % The leadfield weight may be used to specify a (normalized) corresponding surface
 % area for each dipole, e.g. when the dipoles represent a folded cortical surface
@@ -140,6 +140,10 @@ end
 Ndipoles = numel(dippos)/3;
 if all(size(dippos)==[1 3*Ndipoles])
   dippos = reshape(dippos, 3, Ndipoles)';
+end
+
+if isscalar(weight)
+  weight = weight * ones(Ndipoles, 1);
 end
 
 if isfield(headmodel, 'unit') && isfield(sens, 'unit') && ~strcmp(headmodel.unit, sens.unit)
@@ -572,8 +576,8 @@ end
 if ~isempty(weight)
   for i=1:Ndipoles
     lf(:, 3*(i-1)+1) = lf(:, 3*(i-1)+1) * weight(i); % the leadfield for the x-direction
-    lf(:, 3*(i-1)+2) = lf(:, 3*(i-2)+1) * weight(i); % the leadfield for the y-direction
-    lf(:, 3*(i-1)+3) = lf(:, 3*(i-3)+1) * weight(i); % the leadfield for the z-direction
+    lf(:, 3*(i-1)+2) = lf(:, 3*(i-1)+2) * weight(i); % the leadfield for the y-direction
+    lf(:, 3*(i-1)+3) = lf(:, 3*(i-1)+3) * weight(i); % the leadfield for the z-direction
   end
 end
 

--- a/forward/ft_compute_leadfield.m
+++ b/forward/ft_compute_leadfield.m
@@ -1,10 +1,9 @@
 function [lf] = ft_compute_leadfield(dippos, sens, headmodel, varargin)
 
 % FT_COMPUTE_LEADFIELD computes a forward solution for a dipole in a a volume
-% conductor model. The forward solution is expressed as the leadfield
-% matrix (Nchan*3), where each column corresponds with the potential or field
-% distributions on all sensors for one of the x,y,z-orientations of the
-% dipole.
+% conductor model. The forward solution is expressed as the leadfield matrix
+% (Nchan*3), where each column corresponds with the potential or field distributions
+% on all sensors for one of the x,y,z-orientations of the dipole.
 %
 % Use as
 %   [lf] = ft_compute_leadfield(dippos, sens, headmodel, ...)
@@ -28,19 +27,18 @@ function [lf] = ft_compute_leadfield(dippos, sens, headmodel, varargin)
 % Additional input arguments can be specified as key-value pairs, supported
 % optional arguments are
 %   'reducerank'      = 'no' or number
+%   'backproject'     = 'yes' or 'no', in the case of a rank reduction this parameter determines whether the result will be backprojected onto the original subspace (default = 'yes')
 %   'normalize'       = 'no', 'yes' or 'column'
 %   'normalizeparam'  = parameter for depth normalization (default = 0.5)
 %   'weight'          = number or 1xN vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
-%   'backproject'     = 'yes' (default) or 'no', in the case of a rank reduction this parameter determines whether the result will be backprojected onto the original subspace
 %
-% The leadfield weight may be used to specify a (normalized)
-% corresponding surface area for each dipole, e.g. when the dipoles
-% represent a folded cortical surface with varying triangle size.
+% The leadfield weight may be used to specify a (normalized) corresponding surface
+% area for each dipole, e.g. when the dipoles represent a folded cortical surface
+% with varying triangle size.
 %
-% Depending on the specific input arguments for the sensor and volume, this
-% function will select the appropriate low-level EEG or MEG forward model.
-% The leadfield matrix for EEG will have an average reference over all the
-% electrodes.
+% Depending on the specific input arguments for the sensor and volume, this function
+% will select the appropriate low-level EEG or MEG forward model. The leadfield
+% matrix for EEG will have an average reference over all the electrodes.
 %
 % The supported forward solutions for MEG are
 %   infinite homogenous medium
@@ -64,7 +62,7 @@ function [lf] = ft_compute_leadfield(dippos, sens, headmodel, varargin)
 % FT_HEADMODEL_SINGLESHELL, FT_HEADMODEL_SINGLESPHERE,
 % FT_HEADMODEL_HALFSPACE
 
-% Copyright (C) 2004-2016, Robert Oostenveld
+% Copyright (C) 2004-2020, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.

--- a/forward/ft_prepare_vol_sens.m
+++ b/forward/ft_prepare_vol_sens.m
@@ -1,9 +1,8 @@
 function [headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, varargin)
 
-% FT_PREPARE_VOL_SENS does some bookkeeping to ensure that the volume
-% conductor model and the sensor array are ready for subsequent forward
-% leadfield computations. It takes care of some pre-computations that can
-% be done efficiently prior to the leadfield calculations.
+% FT_PREPARE_VOL_SENS does some bookkeeping to ensure that the volume conductor model
+% and the sensor array are ready for subsequent forward leadfield computations and
+% takes care of some pre-computations to make the calculations more efficient.
 %
 % Use as
 %   [headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, ...)
@@ -37,7 +36,7 @@ function [headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, varargin)
 %
 % See also FT_COMPUTE_LEADFIELD, FT_READ_HEADMODEL, FT_READ_SENS
 
-% Copyright (C) 2004-2015, Robert Oostenveld
+% Copyright (C) 2004-2020, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.

--- a/ft_dipolefitting.m
+++ b/ft_dipolefitting.m
@@ -72,7 +72,7 @@ function [source] = ft_dipolefitting(cfg, data)
 %   cfg.reducerank      = 'no', or number (default = 3 for EEG, 2 for MEG)
 %   cfg.normalize       = 'no', 'yes' or 'column'
 %   cfg.normalizeparam  = parameter for depth normalization (default = 0.5)
-%   cfg.weight          = number or 1xN vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
+%   cfg.weight          = number or Nx1 vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
 %   cfg.backproject     = 'yes' (default) or 'no', in the case of a rank reduction this parameter determines whether the result will be backprojected onto the original subspace
 %
 % The volume conduction model of the head should be specified as

--- a/ft_prepare_leadfield.m
+++ b/ft_prepare_leadfield.m
@@ -36,8 +36,8 @@ function [sourcemodel, cfg] = ft_prepare_leadfield(cfg, data)
 %   cfg.elec          = structure with electrode positions or filename, see FT_READ_SENS
 %   cfg.grad          = structure with gradiometer definition or filename, see FT_READ_SENS
 %
-% Optionally, you can modify the leadfields by reducing the rank (i.e.
-% remove the weakest orientation), or by normalizing each column.
+% Optionally, you can modify the leadfields by reducing the rank (i.e. remove the
+% weakest orientation), or by normalizing each column.
 %   cfg.reducerank      = 'no', or number (default = 3 for EEG, 2 for MEG)
 %   cfg.backproject     = 'yes' or 'no',  determines when reducerank is applied whether the 
 %                         lower rank leadfield is projected back onto the original linear 
@@ -139,11 +139,6 @@ cfg = ft_checkconfig(cfg, 'renamed', {'gradfile', 'grad'});
 cfg = ft_checkconfig(cfg, 'renamed', {'optofile', 'opto'});
 
 % set the defaults
-cfg.reducerank     = ft_getopt(cfg, 'reducerank');            % the default for this depends on EEG/MEG and is set below
-cfg.backproject    = ft_getopt(cfg, 'backproject',    'yes'); % determines whether after rank reduction the subspace projected leadfield is backprojected onto the original space
-cfg.normalize      = ft_getopt(cfg, 'normalize',      'no');
-cfg.normalizeparam = ft_getopt(cfg, 'normalizeparam', 0.5);
-cfg.weight         = ft_getopt(cfg, 'weight');
 cfg.lbex           = ft_getopt(cfg, 'lbex',           'no');
 cfg.sel50p         = ft_getopt(cfg, 'sel50p',         'no');
 cfg.feedback       = ft_getopt(cfg, 'feedback',       'text');
@@ -170,15 +165,6 @@ end
 
 % collect and preprocess the electrodes/gradiometer and head model
 [headmodel, sens, cfg] = prepare_headmodel(cfg, data);
-
-if isempty(cfg.reducerank)
-  % set the default for reducing the rank of the leadfields
-  if ft_senstype(sens, 'eeg')
-    cfg.reducerank = ft_getopt(cfg, 'reducerank', 3);
-  else
-    cfg.reducerank = ft_getopt(cfg, 'reducerank', 2);
-  end
-end
 
 % construct the sourcemodel for which the leadfield will be computed
 tmpcfg           = keepfields(cfg, {'sourcemodel', 'mri', 'headshape', 'symmetry', 'smooth', 'threshold', 'spheremesh', 'inwardshift', 'xgrid' 'ygrid', 'zgrid', 'resolution', 'tight', 'warpmni', 'template', 'showcallinfo'});
@@ -208,11 +194,11 @@ end
 
 % construct the low-level options for the leadfield computation as key-value pairs, these are passed to FT_COMPUTE_LEADFIELD and DIPOLE_FIT
 leadfieldopt = {};
-leadfieldopt = ft_setopt(leadfieldopt, 'reducerank',     cfg.reducerank);
-leadfieldopt = ft_setopt(leadfieldopt, 'normalize',      cfg.normalize);
-leadfieldopt = ft_setopt(leadfieldopt, 'normalizeparam', cfg.normalizeparam);
-leadfieldopt = ft_setopt(leadfieldopt, 'weight',         cfg.weight);
-leadfieldopt = ft_setopt(leadfieldopt, 'backproject',    cfg.backproject);
+leadfieldopt = ft_setopt(leadfieldopt, 'reducerank',     ft_getopt(cfg, 'reducerank'));
+leadfieldopt = ft_setopt(leadfieldopt, 'backproject',    ft_getopt(cfg, 'backproject'));
+leadfieldopt = ft_setopt(leadfieldopt, 'normalize',      ft_getopt(cfg, 'normalize'));
+leadfieldopt = ft_setopt(leadfieldopt, 'normalizeparam', ft_getopt(cfg, 'normalizeparam'));
+leadfieldopt = ft_setopt(leadfieldopt, 'weight',         ft_getopt(cfg, 'weight'));
 
 if ft_headmodeltype(headmodel, 'openmeeg')
   

--- a/ft_prepare_leadfield.m
+++ b/ft_prepare_leadfield.m
@@ -39,17 +39,19 @@ function [sourcemodel, cfg] = ft_prepare_leadfield(cfg, data)
 % Optionally, you can modify the leadfields by reducing the rank (i.e.
 % remove the weakest orientation), or by normalizing each column.
 %   cfg.reducerank      = 'no', or number (default = 3 for EEG, 2 for MEG)
+%   cfg.backproject     = 'yes' or 'no',  determines when reducerank is applied whether the 
+%                         lower rank leadfield is projected back onto the original linear 
+%                         subspace, or not (default = 'yes')
 %   cfg.normalize       = 'yes' or 'no' (default = 'no')
 %   cfg.normalizeparam  = depth normalization parameter (default = 0.5)
-%   cfg.backproject     = 'yes' or 'no' (default = 'yes') determines when reducerank is applied
-%                         whether the lower rank leadfield is projected back onto the original
-%                         linear subspace, or not.
+%   cfg.weight          = number or 1xN vector, weight for each dipole position to compensate 
+%                         for the size of the corresponding patch (default = 1)
 %
 % Depending on the type of headmodel, some additional options may be
 % specified.
 %
 % For OPENMEEG based headmodels:
-%   cfg.openmeeg.batchsize    = scalar (default 100e3), number of dipoles
+%   cfg.openmeeg.batchsize    = scalar (default 1e4), number of dipoles
 %                               for which the leadfield is computed in a
 %                               single call to the low-level code. Trades off
 %                               memory efficiency for speed.
@@ -137,6 +139,8 @@ cfg = ft_checkconfig(cfg, 'renamed', {'gradfile', 'grad'});
 cfg = ft_checkconfig(cfg, 'renamed', {'optofile', 'opto'});
 
 % set the defaults
+cfg.reducerank     = ft_getopt(cfg, 'reducerank');            % the default for this depends on EEG/MEG and is set below
+cfg.backproject    = ft_getopt(cfg, 'backproject',    'yes'); % determines whether after rank reduction the subspace projected leadfield is backprojected onto the original space
 cfg.normalize      = ft_getopt(cfg, 'normalize',      'no');
 cfg.normalizeparam = ft_getopt(cfg, 'normalizeparam', 0.5);
 cfg.lbex           = ft_getopt(cfg, 'lbex',           'no');
@@ -144,8 +148,6 @@ cfg.sel50p         = ft_getopt(cfg, 'sel50p',         'no');
 cfg.feedback       = ft_getopt(cfg, 'feedback',       'text');
 cfg.mollify        = ft_getopt(cfg, 'mollify',        'no');
 cfg.patchsvd       = ft_getopt(cfg, 'patchsvd',       'no');
-cfg.backproject    = ft_getopt(cfg, 'backproject',    'yes'); % determines whether after rank reduction the subspace projected leadfield is backprojected onto the original space
-% cfg.reducerank   = ft_getopt(cfg, 'reducerank', 'no');      % the default for this depends on EEG/MEG and is set below
 
 cfg = ft_checkconfig(cfg, 'renamed', {'tightgrid', 'tight'});  % this is moved to cfg.sourcemodel.tight by the subsequent createsubcfg
 cfg = ft_checkconfig(cfg, 'renamed', {'sourceunits', 'unit'}); % this is moved to cfg.sourcemodel.unit by the subsequent createsubcfg
@@ -168,11 +170,13 @@ end
 % collect and preprocess the electrodes/gradiometer and head model
 [headmodel, sens, cfg] = prepare_headmodel(cfg, data);
 
-% set the default for reducing the rank of the leadfields
-if ft_senstype(sens, 'eeg')
-  cfg.reducerank = ft_getopt(cfg, 'reducerank', 3);
-else
-  cfg.reducerank = ft_getopt(cfg, 'reducerank', 2);
+if isempty(cfg.reducerank)
+  % set the default for reducing the rank of the leadfields
+  if ft_senstype(sens, 'eeg')
+    cfg.reducerank = ft_getopt(cfg, 'reducerank', 3);
+  else
+    cfg.reducerank = ft_getopt(cfg, 'reducerank', 2);
+  end
 end
 
 % construct the sourcemodel for which the leadfield will be computed
@@ -185,6 +189,9 @@ elseif ft_senstype(sens, 'meg')
 end
 sourcemodel = ft_prepare_sourcemodel(tmpcfg);
 
+% find the indices of all sourcemodel points that are inside the brain
+insideindx = find(sourcemodel.inside);
+
 % check whether units are equal (NOTE: this was previously not required,
 % this check can be removed if the underlying bug is resolved. See
 % http://bugzilla.fieldtriptoolbox.org/show_bug.cgi?id=2387
@@ -196,8 +203,15 @@ else
   end
 end
 
-% find the indices of all sourcemodel points that are inside the brain
-insideindx = find(sourcemodel.inside);
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% construct the low-level options for the leadfield computation as key-value pairs, these are passed to FT_COMPUTE_LEADFIELD and DIPOLE_FIT
+leadfieldopt = {};
+leadfieldopt = ft_setopt(leadfieldopt, 'reducerank',     cfg.reducerank);
+leadfieldopt = ft_setopt(leadfieldopt, 'normalize',      cfg.normalize);
+leadfieldopt = ft_setopt(leadfieldopt, 'normalizeparam', cfg.normalizeparam);
+leadfieldopt = ft_setopt(leadfieldopt, 'weight',         cfg.weight);
+leadfieldopt = ft_setopt(leadfieldopt, 'backproject',    cfg.backproject);
 
 if ft_headmodeltype(headmodel, 'openmeeg')
   
@@ -210,7 +224,7 @@ if ft_headmodeltype(headmodel, 'openmeeg')
   if(~isfield(cfg,'openmeeg'))
     cfg.openmeeg = [];
   end
-  batchsize   = ft_getopt(cfg.openmeeg, 'batchsize',10e4);  % number of voxels per DSM batch; set to e.g. 1000 if not much RAM available
+  batchsize   = ft_getopt(cfg.openmeeg, 'batchsize',1e4);   % number of voxels per DSM batch; set to e.g. 1000 if not much RAM available
   dsm         = ft_getopt(cfg.openmeeg, 'dsm');             % reuse existing DSM if provided
   keepdsm     = ft_getopt(cfg.openmeeg, 'keepdsm', 'no');   % retain DSM
   nonadaptive = ft_getopt(cfg.openmeeg, 'nonadaptive', 'no');
@@ -262,7 +276,7 @@ if ft_headmodeltype(headmodel, 'openmeeg')
 
   % lead field computation already done, but pass to ft_compute_leadfield so that
   % any post-computation options can be applied (e.g., normalization, etc.)
-  lf = ft_compute_leadfield(sourcemodel.pos(diprange,:), sens, headmodel, 'lf', lf, 'reducerank', cfg.reducerank, 'normalize', cfg.normalize, 'normalizeparam', cfg.normalizeparam, 'backproject', cfg.backproject);
+  lf = ft_compute_leadfield(sourcemodel.pos(diprange,:), sens, headmodel, 'lf', lf, leadfieldopt{:});
 
   % reshape result into sourcemodel.leadfield cell-array
   for i=1:ndip
@@ -285,7 +299,7 @@ elseif ft_headmodeltype(headmodel, 'singleshell')
   for k = 1:numchunks
     ft_progress(k/numchunks, 'computing leadfield %d/%d\n', k, numchunks);
     diprange = (((k-1)*batchsize + 1):(min(k*batchsize,ndip)));
-    tmp      = ft_compute_leadfield(dippos(diprange,:), sens, headmodel, 'reducerank', cfg.reducerank, 'normalize', cfg.normalize, 'normalizeparam', cfg.normalizeparam, 'backproject', cfg.backproject);
+    tmp      = ft_compute_leadfield(dippos(diprange,:), sens, headmodel, leadfieldopt{:});
     for i=1:length(diprange)
       thisindx = insideindx(diprange(i));
       if istrue(cfg.backproject)
@@ -303,7 +317,7 @@ else
     % compute the leadfield on all sourcemodel positions inside the brain
     ft_progress(i/length(insideindx), 'computing leadfield %d/%d\n', i, length(insideindx));
     thisindx = insideindx(i);
-    sourcemodel.leadfield{thisindx} = ft_compute_leadfield(sourcemodel.pos(thisindx,:), sens, headmodel, 'reducerank', cfg.reducerank, 'normalize', cfg.normalize, 'normalizeparam', cfg.normalizeparam, 'backproject', cfg.backproject);
+    sourcemodel.leadfield{thisindx} = ft_compute_leadfield(sourcemodel.pos(thisindx,:), sens, headmodel, leadfieldopt{:});
   end % for all sourcemodel locations inside the brain
   ft_progress('close');
 end

--- a/ft_prepare_leadfield.m
+++ b/ft_prepare_leadfield.m
@@ -44,7 +44,7 @@ function [sourcemodel, cfg] = ft_prepare_leadfield(cfg, data)
 %                         subspace, or not (default = 'yes')
 %   cfg.normalize       = 'yes' or 'no' (default = 'no')
 %   cfg.normalizeparam  = depth normalization parameter (default = 0.5)
-%   cfg.weight          = number or 1xN vector, weight for each dipole position to compensate 
+%   cfg.weight          = number or Nx1 vector, weight for each dipole position to compensate 
 %                         for the size of the corresponding patch (default = 1)
 %
 % Depending on the type of headmodel, some additional options may be
@@ -143,6 +143,7 @@ cfg.reducerank     = ft_getopt(cfg, 'reducerank');            % the default for 
 cfg.backproject    = ft_getopt(cfg, 'backproject',    'yes'); % determines whether after rank reduction the subspace projected leadfield is backprojected onto the original space
 cfg.normalize      = ft_getopt(cfg, 'normalize',      'no');
 cfg.normalizeparam = ft_getopt(cfg, 'normalizeparam', 0.5);
+cfg.weight         = ft_getopt(cfg, 'weight');
 cfg.lbex           = ft_getopt(cfg, 'lbex',           'no');
 cfg.sel50p         = ft_getopt(cfg, 'sel50p',         'no');
 cfg.feedback       = ft_getopt(cfg, 'feedback',       'text');

--- a/ft_prepare_sourcemodel.m
+++ b/ft_prepare_sourcemodel.m
@@ -174,7 +174,9 @@ end
 
 % the source model can be constructed in a number of ways
 if isempty(cfg.method)
-  if isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid)
+  if isfield(cfg, 'sourcemodel') && ischar(cfg.sourcemodel)
+    cfg.method = 'basedonfile';
+  elseif isfield(cfg, 'xgrid') && ~ischar(cfg.xgrid)
     cfg.method = 'basedongrid'; % regular 3D grid with explicit specification
   elseif isfield(cfg.sourcemodel, 'pos')
     cfg.method = 'basedonpos'; % using user-supplied positions, which can be regular or irregular
@@ -190,8 +192,6 @@ if isempty(cfg.method)
     cfg.method = 'basedonresolution'; % regular 3D grid with specification of the resolution
   elseif ~isempty(cfg.headmodel)
     cfg.method = 'basedonvol'; % surface mesh based on inward shifted brain surface from volume conductor
-  elseif isfield(cfg, 'sourcemodel') && ischar(cfg.sourcemodel)
-    cfg.method = 'basedonfile';
   else
     ft_error('incorrect cfg specification for constructing a sourcemodel');
   end

--- a/ft_sourceanalysis.m
+++ b/ft_sourceanalysis.m
@@ -1060,7 +1060,13 @@ if exist('dip', 'var')
 
   if istrue(cfg.(cfg.method).keepfilter) && isfield(dip(1), 'filter')
     for k=1:numel(dip)
-      dip(k).label        = sens.label;
+      if isfield(sourcemodel, 'leadfield')
+        % pre-computed leadfields were used
+        dip(k).label = sourcemodel.label;
+      else
+        % leadfields were computed on the fly
+        dip(k).label = sens.label;
+      end
       dip(k).filterdimord = '{pos}_ori_chan';
     end
   end

--- a/ft_sourceanalysis.m
+++ b/ft_sourceanalysis.m
@@ -206,25 +206,6 @@ else
   cfg.method = ft_getopt(cfg, 'method', []);
 end
 
-cfg.keepleadfield    = ft_getopt(cfg, 'keepleadfield', 'no');
-cfg.keeptrials       = ft_getopt(cfg, 'keeptrials', 'no');
-cfg.trialweight      = ft_getopt(cfg, 'trialweight', 'equal');
-cfg.jackknife        = ft_getopt(cfg, 'jackknife',   'no');
-cfg.pseudovalue      = ft_getopt(cfg, 'pseudovalue', 'no');
-cfg.bootstrap        = ft_getopt(cfg, 'bootstrap',   'no');
-cfg.singletrial      = ft_getopt(cfg, 'singletrial', 'no');
-cfg.rawtrial         = ft_getopt(cfg, 'rawtrial',    'no');
-cfg.randomization    = ft_getopt(cfg, 'randomization', 'no');
-cfg.numrandomization = ft_getopt(cfg, 'numrandomization', 100);
-cfg.permutation      = ft_getopt(cfg, 'permutation',      'no');
-cfg.numpermutation   = ft_getopt(cfg, 'numpermutation',   100);
-cfg.wakewulf         = ft_getopt(cfg, 'wakewulf', 'yes');
-cfg.killwulf         = ft_getopt(cfg, 'killwulf', 'yes');
-cfg.channel          = ft_getopt(cfg, 'channel',  'all');
-cfg.supdip           = ft_getopt(cfg, 'supdip',        []);
-cfg.latency          = ft_getopt(cfg, 'latency',   'all');
-cfg.frequency        = ft_getopt(cfg, 'frequency', 'all');
-
 % put the low-level options pertaining to the source reconstruction method in their own field
 cfg = ft_checkconfig(cfg, 'createsubcfg',  cfg.method);
 % move some fields from cfg.method back to the top-level configuration
@@ -257,6 +238,26 @@ cfg.backproject     = ft_getopt(cfg, 'backproject');
 cfg.normalize       = ft_getopt(cfg, 'normalize');
 cfg.normalizeparam  = ft_getopt(cfg, 'normalizeparam');
 cfg.weight          = ft_getopt(cfg, 'weight');
+
+% get any further options
+cfg.keepleadfield    = ft_getopt(cfg, 'keepleadfield', 'no');
+cfg.keeptrials       = ft_getopt(cfg, 'keeptrials', 'no');
+cfg.trialweight      = ft_getopt(cfg, 'trialweight', 'equal');
+cfg.jackknife        = ft_getopt(cfg, 'jackknife',   'no');
+cfg.pseudovalue      = ft_getopt(cfg, 'pseudovalue', 'no');
+cfg.bootstrap        = ft_getopt(cfg, 'bootstrap',   'no');
+cfg.singletrial      = ft_getopt(cfg, 'singletrial', 'no');
+cfg.rawtrial         = ft_getopt(cfg, 'rawtrial',    'no');
+cfg.randomization    = ft_getopt(cfg, 'randomization', 'no');
+cfg.numrandomization = ft_getopt(cfg, 'numrandomization', 100);
+cfg.permutation      = ft_getopt(cfg, 'permutation',      'no');
+cfg.numpermutation   = ft_getopt(cfg, 'numpermutation',   100);
+cfg.wakewulf         = ft_getopt(cfg, 'wakewulf', 'yes');
+cfg.killwulf         = ft_getopt(cfg, 'killwulf', 'yes');
+cfg.channel          = ft_getopt(cfg, 'channel',  'all');
+cfg.supdip           = ft_getopt(cfg, 'supdip',        []);
+cfg.latency          = ft_getopt(cfg, 'latency',   'all');
+cfg.frequency        = ft_getopt(cfg, 'frequency', 'all');
 
 if hasbaseline && (strcmp(cfg.randomization, 'no') && strcmp(cfg.permutation, 'no'))
   ft_error('input of two conditions only makes sense if you want to randomize or permute');

--- a/inverse/beamformer_dics.m
+++ b/inverse/beamformer_dics.m
@@ -38,9 +38,11 @@ function [dipout] = beamformer_dics(dip, grad, headmodel, dat, Cf, varargin)
 %  'keepcsd'          = remember the estimated cross-spectral density, can be 'yes' or 'no'
 %
 % These options influence the forward computation of the leadfield
-%  'reducerank'       = reduce the leadfield rank, can be 'no' or a number (e.g. 2)
-%  'normalize'        = normalize the leadfield
-%  'normalizeparam'   = parameter for depth normalization (default = 0.5)
+%   reducerank      = 'no', or number (default = 3 for EEG, 2 for MEG)
+%   backproject     = 'yes' or 'no',  determines when reducerank is applied whether the lower rank leadfield is projected back onto the original linear subspace, or not (default = 'yes')
+%   normalize       = 'yes' or 'no' (default = 'no')
+%   normalizeparam  = depth normalization parameter (default = 0.5)
+%   weight          = number or Nx1 vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
 %
 % If the dipole definition only specifies the dipole location, a rotating
 % dipole (regional source) is assumed on each location. If a dipole moment
@@ -531,7 +533,7 @@ switch submethod
     elseif isstruct(refdip) && isfield(refdip, 'pos') % check if only position of refdip is present
       assert(isnumeric(refdip.pos) && numel(refdip.pos)==3);
       lf1 = ft_compute_leadfield(refdip.pos, grad, headmodel, 'reducerank', reducerank, 'normalize', normalize);
-      if isfield(refdip,'mom'); % check for fixed orientation
+      if isfield(refdip,'mom') % check for fixed orientation
         lf1 = lf1.*refdip.mom(:); 
       end 
       filt1 = pinv(lf1' * invCf * lf1) * lf1' * invCf;       % use pinv/SVD to cover rank deficient leadfield

--- a/inverse/beamformer_lcmv.m
+++ b/inverse/beamformer_lcmv.m
@@ -19,6 +19,7 @@ function [dipout] = beamformer_lcmv(dip, grad, headmodel, dat, Cy, varargin)
 % The input dipole model consists of
 %   dipin.pos   positions for dipole, e.g. regular grid, Npositions x 3
 %   dipin.mom   dipole orientation (optional), 3 x Npositions
+% and can additionally contain things like a precomputed filter.
 %
 % Additional options should be specified in key-value pairs and can be
 %  'lambda'           = regularisation parameter
@@ -187,14 +188,14 @@ if isfield(dip, 'subspace')
 elseif ~isempty(subspace)
   % TODO implement an "eigenspace beamformer" as described in Sekihara et al. 2002 in HBM
   fprintf('using data-specific subspace projection\n');
-  if numel(subspace)==1,
+  if numel(subspace)==1
     % interpret this as a truncation of the eigenvalue-spectrum
     % if <1 it is a fraction of the largest eigenvalue
     % if >=1 it is the number of largest eigenvalues
     dat_pre_subspace = dat;
     Cy_pre_subspace  = Cy;
     [u, s, v] = svd(real(Cy));
-    if subspace<1,
+    if subspace<1
       subspace = find(diag(s)./s(1,1) > subspace, 1, 'last');
     end
     Cy       = s(1:subspace,1:subspace);
@@ -265,7 +266,7 @@ for i=1:size(dip.pos,1)
         % optimal orientation calculation for unit-noise gain beamformer,
         % (also applies to similar NAI), based on equation 4.47 from Sekihara & Nagarajan (2008)
         [vv, dd] = eig(pinv(lf' * invCy_squared *lf)*(lf' * invCy *lf));
-        [dum,maxeig]=max(diag(dd));
+        [dum, maxeig]=max(diag(dd));
         eta = vv(:,maxeig);
         lf  = lf * eta;
         if ~isempty(subspace), lforig = lforig * eta; end

--- a/inverse/beamformer_sam.m
+++ b/inverse/beamformer_sam.m
@@ -44,6 +44,7 @@ meansphereorigin  = ft_getopt(varargin, 'meansphereorigin');
 feedback          = ft_getopt(varargin, 'feedback', 'text');
 lambda            = ft_getopt(varargin, 'lambda', 0);
 fixedori          = ft_getopt(varargin, 'fixedori', 'spinning');
+
 % these settings pertain to the forward model, the defaults are set in ft_compute_leadfield
 reducerank        = ft_getopt(varargin, 'reducerank');
 normalize         = ft_getopt(varargin, 'normalize');

--- a/inverse/dipole_fit.m
+++ b/inverse/dipole_fit.m
@@ -19,7 +19,7 @@ function [dipout] = dipole_fit(dip, sens, headmodel, dat, varargin)
 %   'reducerank'      = 'no' or number
 %   'normalize'       = 'no', 'yes' or 'column'
 %   'normalizeparam'  = parameter for depth normalization (default = 0.5)
-%   'weight'          = number or 1xN vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
+%   'weight'          = number or Nx1 vector, weight for each dipole position to compensate for the size of the corresponding patch (default = 1)
 %   'backproject'     = 'yes' (default) or 'no', in the case of a rank reduction this parameter determines whether the result will be backprojected onto the original subspace
 %
 % The constraints on the source model are specified in a structure

--- a/inverse/minimumnormestimate.m
+++ b/inverse/minimumnormestimate.m
@@ -19,10 +19,9 @@ function [dipout] = minimumnormestimate(dip, grad, headmodel, dat, varargin)
 %   'prewhiten'        = 'no' or 'yes', prewhiten the leadfield matrix with the noise covariance matrix C
 %   'scalesourcecov'   = 'no' or 'yes', scale the source covariance matrix R such that trace(leadfield*R*leadfield')/trace(C)=1
 %
-% Note that leadfield normalization (depth regularisation) should be done
-% by scaling the leadfields outside this function, e.g. in
-% prepare_leadfield. Note also that with precomputed leadfields the
-% normalization parameters will not have an effect.
+% Note that leadfield normalization (depth regularisation) should be done by scaling
+% the leadfields outside this function, e.g. in FT_PREPARE_LEADFIELD. Note also that
+% with precomputed leadfields the normalization parameters will not have an effect.
 %
 % This implements
 % * Dale AM, Liu AK, Fischl B, Buckner RL, Belliveau JW, Lewine JD,

--- a/private/freq2timelock.m
+++ b/private/freq2timelock.m
@@ -68,7 +68,7 @@ elseif isfield(freq, 'crsspctrm')
   % concatenate the real and imaginary part
   avg = [real(spctrm) imag(spctrm)];
 else
-  ft_error('unknown representation of frequency domain data');
+  ft_error('cannot convert this representation of frequency domain data');
 end
 
 timelock        = [];

--- a/private/prepare_freq_matrices.m
+++ b/private/prepare_freq_matrices.m
@@ -79,8 +79,8 @@ if isfield(freq, 'crsspctrm')
 	dimtok  = tokenize(getdimord(freq, 'crsspctrm'),'_');
 	hasfull = sum(strcmp(dimtok, 'chan'))==2;
 end
-if ~hasfull,
-	if keeptrials,
+if ~hasfull
+	if keeptrials
 		freq = ft_checkdata(freq, 'cmbrepresentation', 'full');
 	else
 		freq = ft_checkdata(freq, 'cmbrepresentation', 'fullfast');

--- a/private/prepare_headmodel.m
+++ b/private/prepare_headmodel.m
@@ -13,12 +13,12 @@ function [headmodel, sens, cfg] = prepare_headmodel(cfg, data)
 % the skin surface of a BEM head model.
 %
 % This function will return the electrodes/gradiometers in an order that is
-% consistent with the order in cfg.channel, or in case that is empty in the
-% order of the input electrode/gradiometer definition.
+% consistent with the order in cfg.channel, or - in case that is empty - in 
+% the order of the input electrode/gradiometer definition.
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Copyright (C) 2004-2012, Robert Oostenveld
+% Copyright (C) 2004-2020, Robert Oostenveld
 %
 % This file is part of FieldTrip, see http://www.fieldtriptoolbox.org
 % for the documentation and details.
@@ -39,6 +39,7 @@ function [headmodel, sens, cfg] = prepare_headmodel(cfg, data)
 % $Id$
 
 cfg = ft_checkconfig(cfg, 'forbidden', 'order');
+cfg = ft_checkconfig(cfg, 'required', 'headmodel');
 
 % set the defaults
 cfg.channel  = ft_getopt(cfg, 'channel', 'all');
@@ -109,17 +110,12 @@ else
   cfg.channel = ft_channelselection(cfg.channel, sens.label);
 end
 
-% ensure that these are a struct, which may be required in case configuration tracking is used
-% FIXME this fails for combined EEG+MEG
-% headmodel = struct(headmodel);
-% sens      = struct(sens);
-
 % the prepare_vol_sens function from the forwinv module does most of the actual work
 [headmodel, sens] = ft_prepare_vol_sens(headmodel, sens, 'channel', cfg.channel);
 
 % update the selected channels in the configuration
 if iscell(sens)
-  % this represents combined EEG, ECoG and/or MEG
+  % this represents combined EEG, iEEG and/or MEG
   cfg.channel = {};
   for i=1:numel(sens)
     cfg.channel = cat(1, cfg.channel, sens{i}.label(:));

--- a/private/prepare_headmodel.m
+++ b/private/prepare_headmodel.m
@@ -45,6 +45,13 @@ cfg = ft_checkconfig(cfg, 'required', 'headmodel');
 cfg.channel  = ft_getopt(cfg, 'channel', 'all');
 cfg.siunits  = ft_getopt(cfg, 'siunits', 'no');   % yes/no, ensure that SI units are used consistently
 
+% set the defaults for leadfield computation
+cfg.reducerank      = ft_getopt(cfg, 'reducerank');     % the default is handled below
+cfg.backproject     = ft_getopt(cfg, 'backproject');
+cfg.normalize       = ft_getopt(cfg, 'normalize');      % this is better not used in single dipole models
+cfg.normalizeparam  = ft_getopt(cfg, 'normalizeparam'); % this is better not used in single dipole models
+cfg.weight          = ft_getopt(cfg, 'weight');         % this is better not used in single dipole models
+
 hasdata = (nargin>1);
 
 if hasdata
@@ -75,6 +82,15 @@ if hasdata
   sens = ft_fetch_sens(cfg, data);
 else
   sens = ft_fetch_sens(cfg);
+end
+
+if isempty(cfg.reducerank)
+  % set the default for reducing the rank of the leadfields
+  if ft_senstype(sens, 'eeg')
+    cfg.reducerank = ft_getopt(cfg, 'reducerank', 3);
+  else
+    cfg.reducerank = ft_getopt(cfg, 'reducerank', 2);
+  end
 end
 
 if istrue(cfg.siunits)

--- a/test/test_pull1377.m
+++ b/test/test_pull1377.m
@@ -361,7 +361,7 @@ perform_source_analysis
       
       % project through computed filter
       cfg.rawtrial = 'yes';
-      cfg.sourcemodel = keepfields(sourcelcmv3d1, {'pos', 'inside', 'label', 'leadfield', 'filter'});
+      cfg.sourcemodel = keepfields(sourcelcmv3d1, {'pos', 'tri', 'dim', 'inside', 'leadfield', 'leadfielddimord', 'label'});
       ft_sourceanalysis(cfg, MEG_tlck);
       
       % do MNE
@@ -376,7 +376,7 @@ perform_source_analysis
       sourcemne3d1 = ft_datatype_source(sourcemne3d1, 'version', 'latest');
       
       cfg.rawtrial = 'yes';
-      cfg.sourcemodel = keepfields(sourcemne3d1, {'pos', 'inside', 'label', 'leadfield', 'filter'});
+      cfg.sourcemodel = keepfields(sourcemne3d1, {'pos', 'tri', 'dim', 'inside', 'leadfield', 'leadfielddimord', 'label'});
       ft_sourceanalysis(cfg, MEG_tlck);
       
       % do DICS
@@ -393,7 +393,7 @@ perform_source_analysis
       sourcedics3d1 = ft_datatype_source(sourcedics3d1, 'version', 'latest');
       
       cfg.rawtrial = 'yes';
-      cfg.sourcemodel = keepfields(sourcedics3d1, {'pos', 'inside', 'label', 'leadfield', 'filter'});
+      cfg.sourcemodel = keepfields(sourcedics3d1, {'pos', 'tri', 'dim', 'inside', 'leadfield', 'leadfielddimord', 'label'});
       ft_sourceanalysis(cfg, MEG_freq);
       
       % do PCC
@@ -437,7 +437,7 @@ perform_source_analysis
       
       % project through computed filter
       cfg.rawtrial = 'yes';
-      cfg.sourcemodel = keepfields(sourcelcmv3d1, {'pos', 'inside', 'label', 'leadfield', 'filter'});
+      cfg.sourcemodel = keepfields(sourcelcmv3d1, {'pos', 'tri', 'dim', 'inside', 'leadfield', 'leadfielddimord', 'label'});
       ft_sourceanalysis(cfg, EEG_tlck);
       
       % do MNE
@@ -452,7 +452,7 @@ perform_source_analysis
       sourcemne3d1 = ft_datatype_source(sourcemne3d1, 'version', 'latest');
       
       cfg.rawtrial = 'yes';
-      cfg.sourcemodel = keepfields(sourcemne3d1, {'pos', 'inside', 'label', 'leadfield', 'filter'});
+      cfg.sourcemodel = keepfields(sourcemne3d1, {'pos', 'tri', 'dim', 'inside', 'leadfield', 'leadfielddimord', 'label'});
       ft_sourceanalysis(cfg, EEG_tlck);
       
       % do DICS
@@ -468,7 +468,7 @@ perform_source_analysis
       sourcedics3d1 = ft_sourceanalysis(cfg, EEG_freq);
       
       cfg.rawtrial = 'yes';
-      cfg.sourcemodel = keepfields(sourcedics3d1, {'pos', 'inside', 'label', 'leadfield', 'filter'});
+      cfg.sourcemodel = keepfields(sourcedics3d1, {'pos', 'tri', 'dim', 'inside', 'leadfield', 'leadfielddimord', 'label'});
       ft_sourceanalysis(cfg, EEG_freq);
       
       % do PCC

--- a/test/test_pull1377.m
+++ b/test/test_pull1377.m
@@ -24,6 +24,12 @@ function test_pull1377
 % workspaces of the functions that contain them.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+
+% prevent errors from cfg.mne.keepleadfield, etc
+global ft_default
+ft_default.checkconfig = 'loose';
+
+
 datameg = []; % touch these variables to make them shared between the main function and the nexted function
 dataeeg = [];
 

--- a/test/test_pull1377b.m
+++ b/test/test_pull1377b.m
@@ -1,0 +1,208 @@
+function test_pull1377b
+
+% MEM 6gb
+% WALLTIME 1:00:00
+% DEPENDENCY ft_sourceanalysis ft_dipolefitting
+
+load(dccnpath('/home/common/matlab/fieldtrip/data/test/latest/raw/meg/preproc_ctf151.mat'), 'data');
+grad = data.grad;
+clear data
+
+%%
+
+vol = [];
+vol.o = [0 0 4];
+vol.r = 12;
+vol.unit = 'cm';
+vol.type = 'singlesphere';
+
+%%
+
+cfg = [];
+cfg.dip.pos = [0 0 9];
+cfg.dip.mom = [1 0 0];
+cfg.dip.unit = 'cm';
+cfg.headmodel = vol;
+cfg.grad = grad;
+data = ft_dipolesimulation(cfg);
+
+cfg = [];
+timelock = ft_timelockanalysis(cfg, data);
+
+cfg = [];
+cfg.method = 'mtmfft';
+cfg.taper = 'hanning';
+cfg.output = 'fourier';
+freq = ft_freqanalysis(cfg, data);
+
+%%
+
+timelockmethod = {'lcmv', 'sam', 'mne', 'rv', 'music', 'pcc', 'mvl', 'sloreta', 'eloreta'};
+timelockmethod = {'pcc'}; % this is the only one that works
+
+for i=1:numel(timelockmethod)
+  tfdata = timelock;
+  method = timelockmethod{i};
+  test_sourceanalysis
+end
+
+freqmethod = {'dics', 'pcc', 'eloreta', 'mne','harmony', 'rv', 'music'};
+freqmethod = {}; % none of them works
+
+for i=1:numel(freqmethod)
+  tfdata = freq;
+  method = freqmethod{i};
+  test_sourceanalysis
+end
+
+tfdata = timelock;
+test_dipolefitting
+
+% this one does not work
+% tfdata = freq;
+% test_dipolefitting
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+
+  function test_sourceanalysis
+    
+    cfg = [];
+    cfg.sourcemodel.pos = [0 0 7];
+    cfg.sourcemodel.unit = 'cm';
+    cfg.headmodel = vol;
+    cfg.method = method;
+    cfg.keepleadfield = 'yes';
+    cfg.(method).keepfilter = 'yes';
+    cfg.(method).lambda = '10%';
+    cfg.channel = 'MEG';
+    source1 = ft_sourceanalysis(cfg, tfdata);
+    
+    %%
+    % reuse the leadfield
+    
+    cfg = [];
+    cfg.sourcemodel = keepfields(source1, {'pos' 'inside' 'leadfield', 'leadfielddimord', 'label'});
+    cfg.headmodel = vol;
+    cfg.method = method;
+    cfg.(method).lambda = '10%';
+    cfg.channel = 'MEG';
+    source2a = ft_sourceanalysis(cfg, tfdata);
+    
+    %%
+    % reuse the leadfield, but shuffle channels
+    
+    cfg = [];
+    cfg.sourcemodel = keepfields(source1, {'pos' 'inside' 'leadfield', 'leadfielddimord', 'label'});
+    
+    % revert the channel order
+    cfg.sourcemodel.label  = cfg.sourcemodel.label(end:-1:1,:);
+    for i=1:size(cfg.sourcemodel.pos,1)
+      cfg.sourcemodel.leadfield{i} = cfg.sourcemodel.leadfield{i}(end:-1:1,:);
+    end
+    
+    cfg.headmodel = vol;
+    cfg.method = method;
+    cfg.(method).lambda = '10%';
+    cfg.channel = 'MEG';
+    source2b = ft_sourceanalysis(cfg, tfdata);
+    
+    %%
+    % reuse the filter
+    
+    cfg = [];
+    cfg.sourcemodel = keepfields(source1, {'pos' 'inside'});
+    cfg.sourcemodel.label = source1.avg.label;
+    cfg.sourcemodel.filter = source1.avg.filter;
+    cfg.sourcemodel.filterdimord = source1.avg.filterdimord;
+    
+    cfg.headmodel = vol;
+    cfg.method = method;
+    cfg.(method).lambda = '10%';
+    cfg.channel = 'MEG';
+    source2c = ft_sourceanalysis(cfg, tfdata);
+    
+    %%
+    % reuse the filter, but shuffle channels
+    
+    cfg = [];
+    cfg.sourcemodel = keepfields(source1, {'pos' 'inside' 'filter', 'filterdimord', 'label'});
+    cfg.sourcemodel.filter = source1.avg.filter;
+    cfg.sourcemodel.filterdimord = source1.avg.filterdimord;
+    
+    % revert the channel order
+    cfg.sourcemodel.label  = cfg.sourcemodel.label(end:-1:1,:);
+    for i=1:size(cfg.sourcemodel.pos,1)
+      cfg.sourcemodel.filter{i} = cfg.sourcemodel.filter{i}(:,end:-1:1);
+    end
+    
+    cfg.headmodel = vol;
+    cfg.method = method;
+    cfg.(method).lambda = '10%';
+    cfg.channel = 'MEG';
+    source2d = ft_sourceanalysis(cfg, tfdata);
+    
+    %%
+    
+    switch method
+      case {'pcc' 'lcmv'}
+        % these should all be the same
+        assert(isequal(source1.avg.mom, source2a.avg.mom));
+        assert(isequal(source1.avg.mom, source2b.avg.mom));
+        assert(isequal(source1.avg.mom, source2c.avg.mom));
+        assert(isequal(source1.avg.mom, source2d.avg.mom));
+    end
+    
+  end % function test_sourceanalysis
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+
+  function test_dipolefitting
+    
+    cfg = [];
+    cfg.sourcemodel.pos = [0 0 7];
+    cfg.sourcemodel.unit = 'cm';
+    cfg.headmodel = vol;
+    sourcemodel = ft_prepare_leadfield(cfg, tfdata);
+    
+    %%
+    
+    cfg = [];
+    cfg.sourcemodel = sourcemodel;
+    cfg.headmodel = vol;
+    cfg.gridsearch = 'yes';
+    cfg.nonlinear = 'no';
+    cfg.channel = 'MEG';
+    cfg.frequency = [10 11 12]; % only used for frequency data
+    source3a = ft_dipolefitting(cfg, tfdata);
+    
+    %%
+    
+    cfg = [];
+    cfg.sourcemodel = sourcemodel;
+    cfg.headmodel = vol;
+    cfg.gridsearch = 'no';
+    cfg.nonlinear = 'yes';
+    cfg.channel = 'MEG';
+    cfg.frequency = 10; % only used for frequency data
+    source3b = ft_dipolefitting(cfg, tfdata);
+    
+    %%
+    
+    try
+      cfg = [];
+      cfg.sourcemodel = source1;
+      cfg.headmodel = vol;
+      cfg.channel = 'MEGREF'; % the channels in the precomputed leadfield do not include MEGREF
+      cfg.frequency = 10; % only used for frequency data
+      source3c = ft_dipolefitting(cfg, tfdata);
+      passed = true;
+    catch
+      passed = false;
+    end
+    assert(~passed, 'this should have resulted in an error');
+  end % function test_dipolefitting
+
+
+end % function

--- a/utilities/ft_channelselection.m
+++ b/utilities/ft_channelselection.m
@@ -1,14 +1,17 @@
 function [channel] = ft_channelselection(desired, datachannel, senstype)
 
-% FT_CHANNELSELECTION makes a selection of EEG and/or MEG channel labels.
-% This function translates the user-specified list of channels into channel
-% labels as they occur in the data. This channel selection procedure can be
-% used throughout FieldTrip.
+% FT_CHANNELSELECTION makes a selection of EEG and/or MEG channel labels. This
+% function translates the user-specified list of channels into channel labels as they
+% occur in the data. This channel selection procedure can be used throughout
+% FieldTrip.
 %
-% You can specify a mixture of real channel labels and of special strings,
-% or index numbers that will be replaced by the corresponding channel
-% labels. Channels that are not present in the raw datafile are
-% automatically removed from the channel list.
+% You can specify a mixture of real channel labels and of special strings, or index
+% numbers that will be replaced by the corresponding channel labels. Channels that
+% are not present in the raw datafile are automatically removed from the channel
+% list.
+%
+% The order of the channels in the list that is returned corresponds to the order in
+% the data.
 %
 % E.g. the desired input specification can be:
 %   'all'        is replaced by all channels in the datafile
@@ -46,9 +49,6 @@ function [channel] = ft_channelselection(desired, datachannel, senstype)
 %
 % See also FT_PREPROCESSING, FT_SENSLABEL, FT_MULTIPLOTER, FT_MULTIPLOTTFR,
 % FT_SINGLEPLOTER, FT_SINGLEPLOTTFR
-
-% Note that the order of channels that is returned should correspond with
-% the order of the channels in the data.
 
 % Copyright (C) 2003-2016, Robert Oostenveld
 %

--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -302,7 +302,8 @@ if ~isempty(createtopcfg)
           'warpmni'
           'template'
           };
-      case {'lcmv' 'sam' 'dics' 'pcc' 'mne' 'rv' 'music' 'sloreta' 'eloreta'}
+
+      case {'dics' 'eloreta' 'harmony' 'lcmv' 'mne' 'music' 'mvl' 'pcc' 'rv' 'sam' 'sloreta'}
         fieldname = {
           'keepleadfield'
           'backproject'
@@ -311,6 +312,9 @@ if ~isempty(createtopcfg)
           'normalizeparam'
           'weight'
           };
+        
+      otherwise
+        ft_error('unexpected name of the subfunction');
     end % switch subname
     
     for i=1:length(fieldname)

--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -305,6 +305,11 @@ if ~isempty(createtopcfg)
       case {'lcmv' 'sam' 'dics' 'pcc' 'mne' 'rv' 'music' 'sloreta' 'eloreta'}
         fieldname = {
           'keepleadfield'
+          'backproject'
+          'reducerank'
+          'normalize'
+          'normalizeparam'
+          'weight'
           };
     end % switch subname
     

--- a/utilities/ft_checkconfig.m
+++ b/utilities/ft_checkconfig.m
@@ -426,6 +426,7 @@ if ~isempty(createsubcfg)
           'inside'
           'outside'
           'pos'
+          'tri'
           'dim'
           };
 

--- a/utilities/ft_checkdata.m
+++ b/utilities/ft_checkdata.m
@@ -1115,8 +1115,8 @@ elseif strcmp(current, 'sparsewithpow') && strcmp(desired, 'sparse')
 elseif strcmp(current, 'sparse') && strcmp(desired, 'full')
   dimtok = tokenize(data.dimord, '_');
   if ~isempty(strmatch('rpt',   dimtok)), nrpt=size(data.cumtapcnt,1); else nrpt = 1; end
-  if ~isempty(strmatch('freq',  dimtok)), nfrq=numel(data.freq);      else nfrq = 1; end
-  if ~isempty(strmatch('time',  dimtok)), ntim=numel(data.time);      else ntim = 1; end
+  if ~isempty(strmatch('freq',  dimtok)), nfrq=numel(data.freq);       else nfrq = 1; end
+  if ~isempty(strmatch('time',  dimtok)), ntim=numel(data.time);       else ntim = 1; end
   
   if ~isfield(data, 'label')
     % ensure that the bivariate spectral factorization results can be
@@ -1144,9 +1144,9 @@ elseif strcmp(current, 'sparse') && strcmp(desired, 'full')
   complete = all(cmbindx(:)~=0);
   
   % remove obsolete fields
-  try data      = rmfield(data, 'powspctrm');  end
-  try data      = rmfield(data, 'labelcmb');   end
-  try data      = rmfield(data, 'dof');        end
+  try, data = rmfield(data, 'powspctrm');  end
+  try, data = rmfield(data, 'labelcmb');   end
+  try, data = rmfield(data, 'dof');        end
   
   fn = fieldnames(data);
   for ii=1:numel(fn)

--- a/utilities/ft_selectdata.m
+++ b/utilities/ft_selectdata.m
@@ -649,19 +649,23 @@ for k = 1:ndata
   selchannel      = cell(0,1);
   selgrad         = [];
   selelec         = [];
+  selopto         = [];
   if isfield(varargin{k}, 'grad') && isfield(varargin{k}.grad, 'type')
-    % this makes channel selection more robust, e.g. when using wildcards
-    % in cfg.channel
+    % this makes channel selection more robust, e.g. when using wildcards in cfg.channel
     [selgrad, dum] = match_str(varargin{k}.label, varargin{k}.grad.label);
     selchannel     = cat(1, selchannel, ft_channelselection(cfg.channel, varargin{k}.label(selgrad), varargin{k}.grad.type));
   end
   if isfield(varargin{k}, 'elec') && isfield(varargin{k}.elec, 'type')
-    % this makes channel selection more robust, e.g. when using wildcards
-    % in cfg.channel
+    % this makes channel selection more robust, e.g. when using wildcards in cfg.channel
     [selelec, dum] = match_str(varargin{k}.label, varargin{k}.elec.label);
     selchannel     = cat(1, selchannel, ft_channelselection(cfg.channel, varargin{k}.label(selelec), varargin{k}.elec.type));
   end
-  selrest    = setdiff((1:numel(varargin{k}.label))', [selgrad; selelec]);
+  if isfield(varargin{k}, 'opto') && isfield(varargin{k}.opto, 'type')
+    % this makes channel selection more robust, e.g. when using wildcards in cfg.channel
+    [selopto, dum] = match_str(varargin{k}.label, varargin{k}.opto.label);
+    selchannel     = cat(1, selchannel, ft_channelselection(cfg.channel, varargin{k}.label(selelec), varargin{k}.opto.type));
+  end
+  selrest    = setdiff((1:numel(varargin{k}.label))', [selgrad; selelec; selopto]);
   selchannel = cat(1, selchannel, ft_channelselection(cfg.channel, varargin{k}.label(selrest)));
   label      = union(label, selchannel);
 end


### PR DESCRIPTION
Hi @vitpia and @mcpiastra 

This is the final round of improvements for the consistent implementation of keepleadfield, keepfilter, etc. The `test_pull1377` runs through on my local computer, and I expect as well on the compute cluster. I can imagine that there are some other (older) test scripts however that now start giving regression errors, hence I need to test this further before it gets merged and released.   

Can you merge this in your vitpia/flexsource branch? I will then merge https://github.com/fieldtrip/fieldtrip/pull/1377 into fieldtrip/master, then it will undergo additional testing, and then it will be merged in fieldtrip/release. 
 